### PR TITLE
add --no-helper to suppress default.nix generation

### DIFF
--- a/src/npm2nix.coffee
+++ b/src/npm2nix.coffee
@@ -30,6 +30,10 @@ parser.addArgument [ 'output' ],
   type: path.resolve
   metavar: 'OUTPUT'
 
+parser.addArgument [ '--no-helper' ],
+  help: 'Don\'t generate a default.nix expression (when generating for a package.json)'
+  action: 'storeTrue'
+
 parser.addArgument [ '--overwrite' ],
   help: 'Whether to overwrite the helper default.nix expression (when generating for a package.json)',
   action: 'storeTrue',
@@ -212,36 +216,37 @@ npmconf.load (err, conf) ->
       addPackage name, spec for name, spec of packages.devDependencies ? {}
 
       pkgName = escapeNixString packages.name
-      fs.writeFile "default.nix", """
-        { #{pkgName} ? { outPath = ./.; name = "#{pkgName}"; }
-        , pkgs ? import <nixpkgs> {}
-        }:
-        let
-          nodePackages = import "${pkgs.path}/pkgs/top-level/node-packages.nix" {
-            inherit pkgs;
-            inherit (pkgs) stdenv nodejs fetchurl fetchgit;
-            neededNatives = [ pkgs.python ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.utillinux;
-            self = nodePackages;
-            generated = ./#{path.relative process.cwd(), args.output};
-          };
-        in rec {
-          tarball = pkgs.runCommand "#{pkgName}-#{packages.version}.tgz" { buildInputs = [ pkgs.nodejs ]; } ''
-            mv `HOME=$PWD npm pack ${#{pkgName}}` $out
-          '';
-          build = nodePackages.buildNodePackage {
-            name = "#{pkgName}-#{packages.version}";
-            src = [ tarball ];
-            buildInputs = nodePackages.nativeDeps."#{pkgName}" or [];
-            deps = [ #{
-              ("nodePackages.by-spec.\"#{escapeNixString nm}\".\"#{escapeNixString spc}\"" for nm, spc of (packages.dependencies ? {})).join ' '
-            } ];
-            peerDependencies = [];
-            passthru.names = [ "#{pkgName}" ];
-          };
-        }
-        """, flag: "w#{if args.overwrite then '' else 'x'}", (err) ->
-          if err? and err.code isnt 'EEXIST'
-            console.error "Error writing helper default.nix: #{err}"
+      unless args.no_helper
+        fs.writeFile "default.nix", """
+          { #{pkgName} ? { outPath = ./.; name = "#{pkgName}"; }
+          , pkgs ? import <nixpkgs> {}
+          }:
+          let
+            nodePackages = import "${pkgs.path}/pkgs/top-level/node-packages.nix" {
+              inherit pkgs;
+              inherit (pkgs) stdenv nodejs fetchurl fetchgit;
+              neededNatives = [ pkgs.python ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.utillinux;
+              self = nodePackages;
+              generated = ./#{path.relative process.cwd(), args.output};
+            };
+          in rec {
+            tarball = pkgs.runCommand "#{pkgName}-#{packages.version}.tgz" { buildInputs = [ pkgs.nodejs ]; } ''
+              mv `HOME=$PWD npm pack ${#{pkgName}}` $out
+            '';
+            build = nodePackages.buildNodePackage {
+              name = "#{pkgName}-#{packages.version}";
+              src = [ tarball ];
+              buildInputs = nodePackages.nativeDeps."#{pkgName}" or [];
+              deps = [ #{
+                ("nodePackages.by-spec.\"#{escapeNixString nm}\".\"#{escapeNixString spc}\"" for nm, spc of (packages.dependencies ? {})).join ' '
+              } ];
+              peerDependencies = [];
+              passthru.names = [ "#{pkgName}" ];
+            };
+          }
+          """, flag: "w#{if args.overwrite then '' else 'x'}", (err) ->
+            if err? and err.code isnt 'EEXIST'
+              console.error "Error writing helper default.nix: #{err}"
     else
       console.error "#{file} must represent an array of packages or be a valid npm package.json"
       process.exit 4


### PR DESCRIPTION
I use npm2nix to generate npm-deps.nix, which I import as part of my app's .nix expression. I don't actually want a `default.nix` generated, so I've added an `--no-helper` flag to suppress that.

It might be clearer to require `--generate-helper` or something for those who want the helper, but if that's more common then it makes sense to leave it as-is, requiring an additional flag to disable it.
