### PR TITLE
add --include-optional command line argument

### DIFF
--- a/src/npm2nix.coffee
+++ b/src/npm2nix.coffee
@@ -34,6 +34,10 @@ parser.addArgument [ '--overwrite' ],
   help: 'Whether to overwrite the helper default.nix expression (when generating for a package.json)',
   action: 'storeTrue',
 
+parser.addArgument [ '--include-optional' ],
+  help: 'Include optional dependencies that appear in PACKAGES (a comma-separated list of package names, or "*")'
+  metavar: 'PACKAGES'
+
 args = parser.parseArgs()
 
 escapeNixString = (string) ->
@@ -41,6 +45,13 @@ escapeNixString = (string) ->
 
 fullNames = {}
 packageSet = {}
+
+includeOptional = switch args.include_optional
+  when null then -> false
+  when '*' then -> true
+  else
+    includeOptionalNames = args.include_optional.split(',')
+    (name) -> includeOptionalNames.indexOf(name) != -1
 
 writePkg = finalizePkgs = undefined
 do ->
@@ -127,14 +138,17 @@ do ->
           stream.write "(self.nativeDeps.\"#{escapeNixString names[idx]}\" or [])"
         stream.write ";\n    deps = {"
         seenDeps = {}
+        addDep = (nm, spc) ->
+          unless seenDeps[nm]
+            spc = spc.version if spc instanceof Object
+            if spc is 'latest' or spc is ''
+              spc = '*'
+            stream.write "\n      \"#{escapeNixString nm}-#{packageSet[nm][spc].version}\" = self.by-version.\"#{escapeNixString nm}\".\"#{packageSet[nm][spc].version}\";"
+          seenDeps[nm] = true
+
         for idx in [0..count]
-          for nm, spc of pkg.scc[idx].dependencies or {}
-            unless seenDeps[nm]
-              spc = spc.version if spc instanceof Object
-              if spc is 'latest' or spc is ''
-                spc = '*'
-              stream.write "\n      \"#{escapeNixString nm}-#{packageSet[nm][spc].version}\" = self.by-version.\"#{escapeNixString nm}\".\"#{packageSet[nm][spc].version}\";"
-            seenDeps[nm] = true
+          addDep nm, spc for nm, spc of pkg.scc[idx].dependencies or {}
+          addDep nm, spc for nm, spc of pkg.scc[idx].optionalDependencies or {} when includeOptional(nm)
         stream.write "\n    };\n    peerDependencies = ["
         for idx in [0..count]
           for nm, spc of pkg.scc[idx].peerDependencies or {}
@@ -159,7 +173,7 @@ npmconf.load (err, conf) ->
     console.error "Error loading npm config: #{err}"
     process.exit 7
   registry = new RegistryClient conf
-  fetcher = new PackageFetcher()
+  fetcher = new PackageFetcher(includeOptional:includeOptional)
   fs.readFile args.packageList, (err, json) ->
     if err?
       console.error "Error reading file #{args.packageList}: #{err}"

--- a/src/package-fetcher.coffee
+++ b/src/package-fetcher.coffee
@@ -23,6 +23,7 @@ PackageFetcher = (cfg) ->
     new PackageFetcher cfg
   else
     events.EventEmitter.call this
+    @_cfg = cfg
     @_peerDependencies = {}
     this
 
@@ -443,6 +444,9 @@ do ->
       handleDep nm, dep
     for nm, dep of pkg.peerDependencies or {}
       handleDep nm, dep
+    for nm, dep of pkg.optionalDependencies or {}
+      if @_cfg.includeOptional nm
+        handleDep nm, dep
 
     handlePeerDependencies = (peerDependencies) =>
       peerDeps = {}


### PR DESCRIPTION
It accepts a comma-separated list of package names to
include whenever they appear in optionalDependencies,
or "*" to include all optional dependencies.

Sorry for the noise in #12, I had a bit of trouble testing it - turns out the last issue was just a dumb typo. I've fixed that and squashed that branch into just one commit.
