### PR TITLE
Fix half-filled output file

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "lib/package-fetcher.js",
   "dependencies": {
-    "semver": "~4.3.0",
+    "semver": "~4.2.0",
     "argparse": "0.1.15",
     "npm-registry-client": "0.2.27",
     "npmconf": "0.1.1",

--- a/src/package-fetcher.coffee
+++ b/src/package-fetcher.coffee
@@ -40,7 +40,7 @@ PackageFetcher.prototype.fetch = (name, spec, registry) ->
         @_fetchFromGit name, spec, registry, parsed
       when 'http:', 'https:'
         @_fetchFromHTTP name, spec, registry, parsed
-      else
+      when null
         if semver.validRange spec, true
           @_fetchFromRegistry name, spec, registry
         else
@@ -48,6 +48,9 @@ PackageFetcher.prototype.fetch = (name, spec, registry) ->
             @_fetchFromGithub name, spec, registry
           else
             @emit 'error', "Unknown spec #{spec}", name, spec
+      else
+        @emit 'error', "Unknown protocol #{parsed.protocol}", name, spec
+
 
 PackageFetcher.prototype._fetchFromGithub = (name, spec, registry) ->
   new_spec = "git://github.com/" + spec.replace "#", ".git#"

--- a/src/package-fetcher.coffee
+++ b/src/package-fetcher.coffee
@@ -183,7 +183,7 @@ do ->
               cached.callbacks = []
 
             computeHash.on 'readable', ->
-              hashBuf = computeHash.read 32
+              hashBuf = (computeHash.read 32) || hashBuf
               finished() unless hashBuf is null or pkg is null
 
             tarParser.on 'entry', (entry) =>


### PR DESCRIPTION
I had a half-filled output file. This had a few causes and to find out, I needed a number of changes in the npm2nix. These 4 commits are the result. Let me know which ones are not desired.

First (https://github.com/bobvanderlinden/npm2nix/commit/7608cb929611e795b126e3b253918a1ba3edd1bb) downgrading to ~4.2.0, since some packages are not compatible with the new semver yet.

https://github.com/bobvanderlinden/npm2nix/commit/4bc3f6713f1448b410e99efba3cdb9e6e1e85d9b is a bit unrelated, but I thought I'd throw an error when npm2nix comes across a unsupported protocol. I haven't come across such a case yet, but since you mentioned `github:` was introduced recently, I wanted to be sure this wasn't the case for me.

Next, the half-filled output file was caused by some fetching operations not finishing at all. Because of this, `pkgCount` never decreased to 0. With https://github.com/NixOS/npm2nix/commit/d3e6dbfdba9e10a0ae76bc85ed8a215708fdb759, npm2nix will track which packages it is waiting on, instead of just how many. It'll print which packages it is waiting on every 10 seconds, so you know which operations are the troublemakers. It'll also cause node to not exit when there are still packages pending.

Lastly, there were 2 packages that were still pending for me every time I used npm2nix for Popcorn Time (adm-zip and torrent-health). Somehow the tar.gz files of these packages were as most other packages, as `computeHash.read 32` would first return a valid hash and after that returned `null`. In https://github.com/NixOS/npm2nix/commit/6c9245425067d9488ada13c16bbba3b72378619c it'll keep a previously generated hashes when a null-hash was generated.