### PR TITLE
Use NPA to more accurately guess what kind of package this is

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "semver": "~4.2.0",
     "argparse": "0.1.15",
     "npm-registry-client": "7.1.0",
+    "npm-package-arg": "^4.1.0",
     "npmconf": "0.1.1",
     "tar": "0.1.17",
     "temp": "0.6.0",


### PR DESCRIPTION
I had a problem with vector-im/vector-web using https url for git references https://github.com/vector-im/vector-web/blob/develop/package.json#L36 . npm2nix would incorrectly think it is an HTTP dep. This fixes it. May be related to #28 ?
