### PR TITLE
readme: no-dev -> nodev

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Generate nix expressions from npmjs.org!
 Usage
 -----
 
-`npm2nix [--no-dev] node-packages.json node-packages.generated.nix`
+`npm2nix [--nodev] node-packages.json node-packages.generated.nix`
 
-`no-dev` ignores development dependencies
+`nodev` ignores development dependencies
 
 JSON structure
 --------------


### PR DESCRIPTION
The flag name was given incorrectly in the readme file.
