### PR TITLE
Remove only .git directories

### DIFF
--- a/src/package-fetcher.coffee
+++ b/src/package-fetcher.coffee
@@ -326,7 +326,7 @@ do ->
                             @_havePackage name, spec, pkg, registry
                             finished() if hash? and rev?
                         finder = findit gitDir
-                        dotGitRegexp = /^\.git.*$/
+                        dotGitRegexp = /^\.git$/
                         deletesLeft = 1
                         deleteFinished = ->
                           deletesLeft -= 1


### PR DESCRIPTION
This fixes generated hashes after https://github.com/NixOS/nixpkgs/pull/15469. I don't really know *Script so I fixed regexp even though probably simple string comparison can be used now.
