### PR TITLE
Fix url encoding - only workaround so far

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,7 @@ in pkgs.stdenv.mkDerivation rec {
   src = ./.;
   buildInputs = with pkgs; [
     nodejs
+    nodePackages.grunt-cli
   ];
   shellHook = ''
     npm install .

--- a/src/package-fetcher.coffee
+++ b/src/package-fetcher.coffee
@@ -68,7 +68,8 @@ PackageFetcher.prototype._fetchFromRegistry = (name, spec, registry) ->
       else
         @_fetchFromHTTP name, spec, registry, url.parse dist.tarball
 
-  registry.get "https://registry.npmjs.org/#{name}/", {}, (err, info) =>
+  urlName = name.replace '/', '%2f'
+  registry.get "https://registry.npmjs.org/#{urlName}/", {}, (err, info) =>
     if err?
       @emit 'error', "Error getting registry info for #{name}: #{err}", name, spec
     else
@@ -80,7 +81,7 @@ PackageFetcher.prototype._fetchFromRegistry = (name, spec, registry) ->
         if pkg instanceof Object
           handlePackage pkg
         else
-          registry.get "https://registry.npmjs.org/#{name}/#{version}/", (err, info) =>
+          registry.get "https://registry.npmjs.org/#{urlName}/#{version}/", (err, info) =>
             if err?
               @emit 'error', "Error getting package info for #{name}@#{version}: #{err}", name, spec
             else


### PR DESCRIPTION
Got a problem with scoped packages, they have a name like `@type/clone`, got the following in the output:

```
http 404 https://registry.npmjs.org/@types/clone/
Error during fetch: Error getting registry info for @types/clone: Error: Not found : @types
```

When I tried the URL in the browser, I found that changing it to `@types%2fclone/` works fine. 

At the moment the attached change is just a workaround which made it work for me. I am quite sure that this is not the best approach though. Hope I can get some hint how to improve it.
